### PR TITLE
Removed Ambiguity between `Date.now()` and `Date.now`

### DIFF
--- a/Sources/SchwiftyUtilities/extensions/DateExtensions.swift
+++ b/Sources/SchwiftyUtilities/extensions/DateExtensions.swift
@@ -19,9 +19,9 @@ extension Date {
     /// Further testing is required to make sure this function is still necessary.
     @inlinable
     public static func now() -> Date {
-        var d = Date.now
+        var d = Date()
         while Calendar.current.component(.year, from: d) < 2025 {
-            d = Date.now
+            d = Date()
         }
         return d
     }


### PR DESCRIPTION
Closes issue #1